### PR TITLE
feat: added --text-only support for emoji suppression

### DIFF
--- a/terraplanfeed/azuredevops.py
+++ b/terraplanfeed/azuredevops.py
@@ -247,7 +247,7 @@ def sendRequest(url, data, azdo):
     return response.status_code
 
 
-def generate_pr_comment(changes, azdo, textonly = False):
+def generate_pr_comment(changes, azdo, textonly=False):
     """
     Handles changes and formats content to send to Azure DevOps API.
 

--- a/terraplanfeed/cli.py
+++ b/terraplanfeed/cli.py
@@ -64,6 +64,13 @@ def version_msg():
     help="Output driver",
 )
 @click.option(
+    "-t",
+    "--textonly",
+    is_flag=True,
+    help="Text-only output (disable emoji)",
+    default=False,
+)
+@click.option(
     "--azdo-organization",
     default=env.str("SYSTEM_TEAMFOUNDATIONSERVERURI"),
     help="Azure DevOps Organization Service URL",
@@ -98,6 +105,7 @@ def main(
     verbose,
     debug_file,
     output,
+    textonly,
     azdo_organization,
     azdo_project,
     azdo_repository,
@@ -120,7 +128,7 @@ def main(
         "apiversion": azdo_apiversion,
     }
 
-    terraplanfeed(filename, output, azdo_params)
+    terraplanfeed(filename, output, azdo_params, textonly)
 
 
 if __name__ == "__main__":

--- a/terraplanfeed/main.py
+++ b/terraplanfeed/main.py
@@ -17,7 +17,7 @@ from terraplanfeed.azuredevops import generate_pr_comment
 logger = logging.getLogger(__name__)
 
 
-def terraplanfeed(filename, output, azdo):
+def terraplanfeed(filename, output, azdo, textonly):
     """
     Execute terraplanfeed.
 
@@ -25,6 +25,7 @@ def terraplanfeed(filename, output, azdo):
         filename(str): Terraform plan in JSON format
         output(str): output driver to write feedback
         azdo(dict): Azure DevOps parameters
+        textonly(bool): Disable emoji
 
     Returns:
         Boolean
@@ -42,6 +43,6 @@ def terraplanfeed(filename, output, azdo):
     resources = parsePlan(tf)
 
     if output.lower() == "azuredevops":
-        generate_pr_comment(resources, azdo)
+        generate_pr_comment(resources, azdo, textonly)
     else:
-        generate_stdout(resources)
+        generate_stdout(resources, textonly)

--- a/terraplanfeed/stdout.py
+++ b/terraplanfeed/stdout.py
@@ -97,14 +97,14 @@ def write(content):
     print(FOOTER)
 
 
-def generate_stdout(changes, textonly = False):
+def generate_stdout(changes, textonly=False):
     """
     Entrypoint for stdout output driver.
 
     Args:
         changes(list): list of resources dict
         textonly(bool): disable emoji
-   """
+    """
 
     logger.debug("stdout entrypoint")
     if not changes:

--- a/terraplanfeed/stdout.py
+++ b/terraplanfeed/stdout.py
@@ -22,6 +22,15 @@ ACTION_SYMBOLS = {
     "delete": "🛑",
 }
 
+ACTION_TEXT = {
+    "no-op": ".",
+    "create": "+",
+    "read": "r",
+    "update": "U",
+    "replace": "R",
+    "delete": "X",
+}
+
 HEADER = """
 **Terraform Plan changes summary:**
 ===================================
@@ -31,30 +40,33 @@ FOOTER = """
 """
 
 
-def getAction(actions):
+def getAction(actions, textonly):
     """
     Get action
 
     Args:
         actions(list): list of actions
+        textonly(bool): disable emoji
 
     Returns:
         action symbol
     """
 
     logger.debug("get action")
+    lookup = ACTION_TEXT if textonly else ACTION_SYMBOLS
     if "create" in actions and len(actions) > 1:
-        return ACTION_SYMBOLS["replace"]
+        return lookup["replace"]
     else:
-        return ACTION_SYMBOLS[actions[0]]
+        return lookup[actions[0]]
 
 
-def parseChanges(changes):
+def parseChanges(changes, textonly):
     """
     Parse changes.
 
     Args:
         changes(list): list of resources dict
+        textonly(bool): disable emoji
 
     Returns:
         Multiline string with summary of changes
@@ -63,7 +75,7 @@ def parseChanges(changes):
     content = ""
     logger.debug("parsing changes...")
     for c in changes:
-        action = getAction(c["actions"])
+        action = getAction(c["actions"], textonly)
         message = "({action}): {name} ({address})".format(
             action=action, name=c["name"], address=c["address"]
         )
@@ -85,17 +97,18 @@ def write(content):
     print(FOOTER)
 
 
-def generate_stdout(changes):
+def generate_stdout(changes, textonly = False):
     """
     Entrypoint for stdout output driver.
 
     Args:
         changes(list): list of resources dict
-    """
+        textonly(bool): disable emoji
+   """
 
     logger.debug("stdout entrypoint")
     if not changes:
         content = "No changes"
     else:
-        content = parseChanges(changes)
+        content = parseChanges(changes, textonly)
     write(content)


### PR DESCRIPTION
Added a --text-only flag to suppress emoji allowing for slightly easier parsing of the output from terraplanfeed.

I'm not super thrilled about having to cascade the flag down through all the levels in order to modify the behavior of `getAction` but it was significantly less work than implementing a new simplified json output type. _(Our use case consists of capturing replace/delete actions and flagging them as warnings on pipeline run)_

Feel free to decline/bin the PR if the functionality doesn't align with your vision for the project or if you just abhor the way it was ice-picked into your codebase. 😄 