### PR TITLE
feat: added --drift and --detailed-errorcode options

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![pre-commit badge][pre-commit-badge]][pre-commit] [![Conventional commits badge][conventional-commits-badge]][conventional-commits] [![Keep a Changelog v1.1.0 badge][keep-a-changelog-badge]][keep-a-changelog] [![MIT License Badge][license-badge]][license]
 
-This tool parses Terraform plan files in JSON format and gives feedback about the changes.
+This tool parses Terraform plan files in JSON format and gives feedback about the changes or state drift
 
 ## Description
 
@@ -46,6 +46,14 @@ Summary of changes:
 (✨): <known after apply> (module.sql.module.naming_failover.random_string.main)
 
 ```
+
+To monitor state drift rather than changes
+
+```bash
+❯ terraplanfeed --drift ../tfplan/example.json
+```
+
+To output to Azure DevOps
 
 ```bash
 ❯ terraplanfeed ../tfplan/example.json -o azuredevops

--- a/README.md
+++ b/README.md
@@ -53,6 +53,12 @@ To monitor state drift rather than changes
 ❯ terraplanfeed --drift ../tfplan/example.json
 ```
 
+To enable detailed exit codes (0 - no changes, 1 - errored, 2 - changes found)
+
+```bash
+❯ terraplanfeed --detailed-exitcode ../tfplan/example.jso
+```
+
 To output to Azure DevOps
 
 ```bash

--- a/terraplanfeed/cli.py
+++ b/terraplanfeed/cli.py
@@ -8,6 +8,7 @@ Arguments:
     -v, --verbose: prints debug information
     -d, --debug-file: filename to print debug information
     -o, --output: output driver
+    -f, --drift: process resource drift rather than changes
 """
 
 import os
@@ -71,6 +72,13 @@ def version_msg():
     default=False,
 )
 @click.option(
+    "-f",
+    "--drift",
+    is_flag=True,
+    help="Process resource drift rather than changes",
+    default=False,
+)
+@click.option(
     "--azdo-organization",
     default=env.str("SYSTEM_TEAMFOUNDATIONSERVERURI"),
     help="Azure DevOps Organization Service URL",
@@ -106,6 +114,7 @@ def main(
     debug_file,
     output,
     textonly,
+    drift,
     azdo_organization,
     azdo_project,
     azdo_repository,
@@ -128,7 +137,7 @@ def main(
         "apiversion": azdo_apiversion,
     }
 
-    terraplanfeed(filename, output, azdo_params, textonly)
+    terraplanfeed(filename, output, azdo_params, textonly, drift)
 
 
 if __name__ == "__main__":

--- a/terraplanfeed/cli.py
+++ b/terraplanfeed/cli.py
@@ -9,6 +9,7 @@ Arguments:
     -d, --debug-file: filename to print debug information
     -o, --output: output driver
     -f, --drift: process resource drift rather than changes
+    -x, --detailed-exitcode: enable detailed exit codes
 """
 
 import os
@@ -79,6 +80,13 @@ def version_msg():
     default=False,
 )
 @click.option(
+    "-x",
+    "--detailed-exitcode",
+    is_flag=True,
+    help="Enable detailed exit codes",
+    default=False,
+)
+@click.option(
     "--azdo-organization",
     default=env.str("SYSTEM_TEAMFOUNDATIONSERVERURI"),
     help="Azure DevOps Organization Service URL",
@@ -115,6 +123,7 @@ def main(
     output,
     textonly,
     drift,
+    detailed_exitcode,
     azdo_organization,
     azdo_project,
     azdo_repository,
@@ -137,7 +146,7 @@ def main(
         "apiversion": azdo_apiversion,
     }
 
-    terraplanfeed(filename, output, azdo_params, textonly, drift)
+    terraplanfeed(filename, output, azdo_params, textonly, drift, detailed_exitcode)
 
 
 if __name__ == "__main__":

--- a/terraplanfeed/cli.py
+++ b/terraplanfeed/cli.py
@@ -146,7 +146,9 @@ def main(
         "apiversion": azdo_apiversion,
     }
 
-    terraplanfeed(filename, output, azdo_params, textonly, drift, detailed_exitcode)
+    terraplanfeed(
+        filename, output, azdo_params, textonly, drift, detailed_exitcode
+    )
 
 
 if __name__ == "__main__":

--- a/terraplanfeed/main.py
+++ b/terraplanfeed/main.py
@@ -17,7 +17,7 @@ from terraplanfeed.azuredevops import generate_pr_comment
 logger = logging.getLogger(__name__)
 
 
-def terraplanfeed(filename, output, azdo, textonly, drift):
+def terraplanfeed(filename, output, azdo, textonly, drift, detailed_exitcode):
     """
     Execute terraplanfeed.
 
@@ -27,6 +27,7 @@ def terraplanfeed(filename, output, azdo, textonly, drift):
         azdo(dict): Azure DevOps parameters
         textonly(bool): Disable emoji
         drift(bool): Flag denoting drift mode
+        detailed_exitcode(bool): Return detailed exit codes
 
     Returns:
         Boolean
@@ -46,4 +47,4 @@ def terraplanfeed(filename, output, azdo, textonly, drift):
     if output.lower() == "azuredevops":
         generate_pr_comment(resources, azdo, textonly, drift)
     else:
-        generate_stdout(resources, textonly, drift)
+        generate_stdout(resources, textonly, drift, detailed_exitcode)

--- a/terraplanfeed/main.py
+++ b/terraplanfeed/main.py
@@ -17,7 +17,7 @@ from terraplanfeed.azuredevops import generate_pr_comment
 logger = logging.getLogger(__name__)
 
 
-def terraplanfeed(filename, output, azdo, textonly):
+def terraplanfeed(filename, output, azdo, textonly, drift):
     """
     Execute terraplanfeed.
 
@@ -26,6 +26,7 @@ def terraplanfeed(filename, output, azdo, textonly):
         output(str): output driver to write feedback
         azdo(dict): Azure DevOps parameters
         textonly(bool): Disable emoji
+        drift(bool): Flag denoting drift mode
 
     Returns:
         Boolean
@@ -40,9 +41,9 @@ def terraplanfeed(filename, output, azdo, textonly):
             logger.error("%s", e)
             sys.exit(1)
 
-    resources = parsePlan(tf)
+    resources = parsePlan(tf, drift)
 
     if output.lower() == "azuredevops":
-        generate_pr_comment(resources, azdo, textonly)
+        generate_pr_comment(resources, azdo, textonly, drift)
     else:
-        generate_stdout(resources, textonly)
+        generate_stdout(resources, textonly, drift)

--- a/terraplanfeed/stdout.py
+++ b/terraplanfeed/stdout.py
@@ -7,9 +7,11 @@ Functions:
     getAction: gets the action from actions list
     parseChanges: gets list of changes and creates multiline summary
     write: writes the summary content to stdout
+    detexit: exit with detailed exit codes
     main: entrypoint
 """
 import logging
+import sys
 
 logger = logging.getLogger(__name__)
 
@@ -106,7 +108,22 @@ def write(content, drift):
     print(FOOTER)
 
 
-def generate_stdout(changes, textonly=False, drift=False):
+def detexit(content):
+    """
+    Exit with detailed exit codes
+
+    Args:
+        content(str): multiline string
+    """
+
+    logger.debug("exit")
+    if content != "No changes":
+        sys.exit(2)
+    else:
+        sys.exit(0)
+
+
+def generate_stdout(changes, textonly=False, drift=False, detailed_exitcode=False):
     """
     Entrypoint for stdout output driver.
 
@@ -114,6 +131,7 @@ def generate_stdout(changes, textonly=False, drift=False):
         changes(list): list of resources dict
         textonly(bool): disable emoji
         drift(bool): enable drift mode
+        detailed_exitcode(bool): enable detailed exit codes
     """
 
     logger.debug("stdout entrypoint")
@@ -122,3 +140,6 @@ def generate_stdout(changes, textonly=False, drift=False):
     else:
         content = parseChanges(changes, textonly, drift)
     write(content, drift)
+
+    if detailed_exitcode:
+        detexit(content)

--- a/terraplanfeed/stdout.py
+++ b/terraplanfeed/stdout.py
@@ -31,8 +31,13 @@ ACTION_TEXT = {
     "delete": "X",
 }
 
-HEADER = """
+HEADER_CHANGES = """
 **Terraform Plan changes summary:**
+===================================
+"""
+
+HEADER_DRIFT = """
+**Terraform Plan drift summary:**
 ===================================
 """
 
@@ -60,7 +65,7 @@ def getAction(actions, textonly):
         return lookup[actions[0]]
 
 
-def parseChanges(changes, textonly):
+def parseChanges(changes, textonly, drift):
     """
     Parse changes.
 
@@ -83,32 +88,37 @@ def parseChanges(changes, textonly):
     return content
 
 
-def write(content):
+def write(content, drift):
     """
     Writes summary of changes to stdout.
 
     Args:
         content(str): multiline string
+        drift(bool): flag denoting drift mode
     """
 
     logger.debug("write to stdout")
-    print(HEADER)
+    if drift:
+        print(HEADER_DRIFT)
+    else:
+        print(HEADER_CHANGES)
     print(content)
     print(FOOTER)
 
 
-def generate_stdout(changes, textonly=False):
+def generate_stdout(changes, textonly=False, drift=False):
     """
     Entrypoint for stdout output driver.
 
     Args:
         changes(list): list of resources dict
         textonly(bool): disable emoji
+        drift(bool): enable drift mode
     """
 
     logger.debug("stdout entrypoint")
     if not changes:
         content = "No changes"
     else:
-        content = parseChanges(changes, textonly)
-    write(content)
+        content = parseChanges(changes, textonly, drift)
+    write(content, drift)

--- a/terraplanfeed/stdout.py
+++ b/terraplanfeed/stdout.py
@@ -123,7 +123,9 @@ def detexit(content):
         sys.exit(0)
 
 
-def generate_stdout(changes, textonly=False, drift=False, detailed_exitcode=False):
+def generate_stdout(
+    changes, textonly=False, drift=False, detailed_exitcode=False
+):
     """
     Entrypoint for stdout output driver.
 

--- a/terraplanfeed/terraform.py
+++ b/terraplanfeed/terraform.py
@@ -19,25 +19,34 @@ import logging
 logger = logging.getLogger(__name__)
 
 
-def getResourceChanges(data):
+def getResourceChanges(data, drift=False):
     """
     Filters Resource Changes from Plan.
 
-    Retrieves the resource_changes portion from terraform plan.
+    Retrieves the resource_changes or resource_drift portion from terraform plan.
 
     Args:
         data (dict): dict from json.load('<terraform plan in json format>')
+        drift (bool): If true process drift rather than changes
 
     Returns:
-        List of resource_changes
+        List of resource_changes or resource_drift
     """
 
-    logger.debug("filter resource_changes from plan")
-    if "resource_changes" in data.keys():
-        return data["resource_changes"]
+    if drift:
+        logger.debug("filter resource_drift from plan")
+        if "resource_drift" in data.keys():
+            return data["resource_drift"]
+        else:
+            logger.debug("no resource_drift found")
+            return []
     else:
-        logger.error("no resource_changes found")
-        return []
+        logger.debug("filter resource_changes from plan")
+        if "resource_changes" in data.keys():
+            return data["resource_changes"]
+        else:
+            logger.error("no resource_changes found")
+            return []
 
 
 def filterNoOp(resources):
@@ -138,7 +147,7 @@ def getAttributes(data):
     return resources
 
 
-def parsePlan(tfplan):
+def parsePlan(tfplan, drift):
     """
     Parse Terraform plan in JSON.
 
@@ -151,7 +160,7 @@ def parsePlan(tfplan):
 
     logger.debug("parsing file...")
 
-    all_resources = getResourceChanges(tfplan)
+    all_resources = getResourceChanges(tfplan, drift)
     logger.debug(all_resources)
 
     resource_changing = filterNoOp(all_resources)


### PR DESCRIPTION
I have added two features in this pull request to meet my own needs;

1. The --drift option to parse state drift rather than state changes
2. The --detailed-errorcode option to exit 2 if there are changes or drift

I was going to submit them as two pull requests, but there are some unresolvable merge conflicts if I do so and it seemed easier to send them together. Let me know if you want me to do this another way